### PR TITLE
[Reviewer: Andy] Don't spuriously set the 'inclusive' flag on requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean_deb_source :
 
 ${DEBS}: build
 
-build: clearwater2.patch clearwater2.patch
+build: clearwater1.patch clearwater2.patch
 	apt-get source net-snmp=${DEBIANVER}-${UBUNTUVER}
 	patch -p1 < clearwater1.patch
 	patch -p1 < clearwater2.patch

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DEBS := libsnmp30_5.7.2~dfsg-clearwater1_amd64.deb \
         snmpd_5.7.2~dfsg-clearwater1_amd64.deb \
         tkmib_5.7.2~dfsg-clearwater1_all.deb
 
-.PHONY : all clean clean_deb_source
+.PHONY : all clean clean_deb_source build
 all : ${DEBS}
 clean : clean_deb_source
 	-rm ${DEBS}
@@ -20,15 +20,21 @@ clean_deb_source :
 	rm -rf net-snmp-${DEBIANVER}/
 	-rm .*.built
 
-${DEBS} : .clearwater1.built
+net-snmp-5.7.2~dfsg/COPYING:
+	apt-get source net-snmp=${DEBIANVER}-${UBUNTUVER}
+
+${DEBS}: .all_built
 
 .%.built : %.patch
 	touch $@.tmp
-	apt-get source net-snmp=${DEBIANVER}-${UBUNTUVER}
 	patch -p1 < $<
+	mv $@.tmp $@
+
+.all_built: net-snmp-5.7.2~dfsg/COPYING .clearwater1.built .clearwater2.built
 	cd net-snmp-${DEBIANVER} && dpkg-buildpackage -b -us -uc -d
 	${MAKE} clean_deb_source
-	mv $@.tmp $@
+	touch $@
+
 
 .PHONY: print_debs
 print_debs :

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 DEBIANVER := 5.7.2~dfsg
 UBUNTUVER := 8.1ubuntu3.1
 
-DEBS := libsnmp30_5.7.2~dfsg-clearwater1_amd64.deb \
-        libsnmp30-dbg_5.7.2~dfsg-clearwater1_amd64.deb \
-        libsnmp-base_5.7.2~dfsg-clearwater1_all.deb \
-        libsnmp-dev_5.7.2~dfsg-clearwater1_amd64.deb \
-        libsnmp-perl_5.7.2~dfsg-clearwater1_amd64.deb \
-        python-netsnmp_5.7.2~dfsg-clearwater1_amd64.deb \
-        snmp_5.7.2~dfsg-clearwater1_amd64.deb \
-        snmpd_5.7.2~dfsg-clearwater1_amd64.deb \
-        tkmib_5.7.2~dfsg-clearwater1_all.deb
+DEBS := libsnmp30_5.7.2~dfsg-clearwater2_amd64.deb \
+        libsnmp30-dbg_5.7.2~dfsg-clearwater2_amd64.deb \
+        libsnmp-base_5.7.2~dfsg-clearwater2_all.deb \
+        libsnmp-dev_5.7.2~dfsg-clearwater2_amd64.deb \
+        libsnmp-perl_5.7.2~dfsg-clearwater2_amd64.deb \
+        python-netsnmp_5.7.2~dfsg-clearwater2_amd64.deb \
+        snmp_5.7.2~dfsg-clearwater2_amd64.deb \
+        snmpd_5.7.2~dfsg-clearwater2_amd64.deb \
+        tkmib_5.7.2~dfsg-clearwater2_all.deb
 
 .PHONY : all clean clean_deb_source build
 all : ${DEBS}
@@ -18,23 +18,15 @@ clean : clean_deb_source
 clean_deb_source :
 	-rm -f net-snmp_${DEBIANVER}*
 	rm -rf net-snmp-${DEBIANVER}/
-	-rm .*.built
 
-net-snmp-5.7.2~dfsg/COPYING:
+${DEBS}: build
+
+build: clearwater2.patch clearwater2.patch
 	apt-get source net-snmp=${DEBIANVER}-${UBUNTUVER}
-
-${DEBS}: .all_built
-
-.%.built : %.patch
-	touch $@.tmp
-	patch -p1 < $<
-	mv $@.tmp $@
-
-.all_built: net-snmp-5.7.2~dfsg/COPYING .clearwater1.built .clearwater2.built
+	patch -p1 < clearwater1.patch
+	patch -p1 < clearwater2.patch
 	cd net-snmp-${DEBIANVER} && dpkg-buildpackage -b -us -uc -d
 	${MAKE} clean_deb_source
-	touch $@
-
 
 .PHONY: print_debs
 print_debs :

--- a/clearwater2.patch
+++ b/clearwater2.patch
@@ -1,0 +1,49 @@
+diff -r '--unified=3' -N net-snmp-5.7.2~dfsg.orig/debian/changelog net-snmp-5.7.2~dfsg/debian/changelog
+--- net-snmp-orig/net-snmp-5.7.2~dfsg/debian/changelog	2015-12-09 11:09:33.901025715 +0000
++++ net-snmp/net-snmp-5.7.2~dfsg/debian/changelog	2015-12-09 11:13:15.286567033 +0000
+@@ -1,3 +1,10 @@
++net-snmp (5.7.2~dfsg-clearwater2) trusty; urgency=medium
++
++  * Don't spuriously set the 'inclusive' flag on requests
++
++ -- Project Clearwater Maintainers <maintainers@projectclearwater.org>  Tue, 08 Dec 2015 18:28:25 +0000
++
++
+ net-snmp (5.7.2~dfsg-clearwater1) trusty; urgency=medium
+ 
+   * Correct check for OID landing inside proxied space (Closes: #2669)
+diff -r '--unified=3' -N net-snmp-5.7.2~dfsg.orig/debian/patches/inclusiveness.patch net-snmp-5.7.2~dfsg/debian/patches/inclusiveness.patch
+--- net-snmp-orig/net-snmp-5.7.2~dfsg/debian/patches/inclusiveness.patch	1970-01-01 00:00:00.000000000 +0000
++++ net-snmp/net-snmp-5.7.2~dfsg/debian/patches/inclusiveness.patch	2015-12-09 11:11:18.456665759 +0000
+@@ -0,0 +1,23 @@
++Index: net-snmp-5.7.2~dfsg/agent/snmp_agent.c
++===================================================================
++--- net-snmp-5.7.2~dfsg.orig/agent/snmp_agent.c	2015-12-09 11:09:33.000000000 +0000
+++++ net-snmp-5.7.2~dfsg/agent/snmp_agent.c	2015-12-09 11:11:08.602815263 +0000
++@@ -3044,18 +3044,6 @@
++                             "request response %d out of range\n",
++                             request->index));
++                 /*
++-                 * I'm not sure why inclusive is set unconditionally here (see
++-                 * comments for revision 1.161), but it causes a problem for
++-                 * GETBULK over an overridden variable. The bulk-to-next
++-                 * handler re-uses the same request for multiple varbinds,
++-                 * and once inclusive was set, it was never cleared. So, a
++-                 * hack. Instead of setting it to 1, set it to 2, so bulk-to
++-                 * next can clear it later. As of the time of this hack, all
++-                 * checks of this var are boolean checks (not == 1), so this
++-                 * should be safe. Cross your fingers.
++-                 */
++-                request->inclusive = 2;
++-                /*
++                  * XXX: should set this to the original OID? 
++                  */
++                 snmp_set_var_objid(request->requestvb,
+diff -r '--unified=3' -N net-snmp-5.7.2~dfsg.orig/debian/patches/series net-snmp-5.7.2~dfsg/debian/patches/series
+--- net-snmp-orig/net-snmp-5.7.2~dfsg/debian/patches/series	2015-12-09 11:09:33.905026467 +0000
++++ net-snmp/net-snmp-5.7.2~dfsg/debian/patches/series	2015-12-09 11:10:38.397145241 +0000
+@@ -26,3 +26,4 @@
+ CVE-2014-3565.patch
+ CVE-2015-5621.patch
+ correctly-check-proxy-range
++inclusiveness.patch


### PR DESCRIPTION
If we move past the end of a MIB tree, we always set the `request->inclusive` flag - I think this is only valid in AgentX subagents, but we're setting it in the master agent.

This causes problems at https://github.com/haad/net-snmp/blob/master/agent/helpers/instance.c#L771 - we always go through the first branch, never returning SNMP_ERR_NOERROR and moving forwards through the subtrees. This results in the infinite loop described in https://github.com/Metaswitch/clearwater-infrastructure/issues/261.

I'm going to test along with https://github.com/Metaswitch/cpp-common/pull/424 by:
- walking the .1.2 OID space - this should complete in under a minute (i.e. not go through the infinite table) and return results for all the OIDs
- walking the proxied registrations table at .1.2.826.0.1.1578918.9.10.5 while Chronos is down - this should just fail, but not send snmpd into a 100% CPU spiral
- running snmptable on a proxied table and a non-proxied table, and checking that both make sense
- running `snmpgetnext -v2c -r 0 -c clearwater localhost .1.3.6.1.2.1.1.3` and checking that sysUptime (iso.3.6.1.2.1.1.3.0) is returned - i.e. that this fix doesn't make us spuriously skip values

Note that this doesn't actually compile yet - my `correct-inclusiveness` patch doesn't apply cleanly. Applying it manually fails, but applying it manually with whitespace ignored works. I'd like to chat to you about how you generated the previous patches (and one of us should then document that).
