### PR TITLE
[Reviewer: Ellie] Fix FD_ISSET on 64-bit systems

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+net-snmp (5.7.2~dfsg-clearwater6) trusty; urgency=medium
+
+  * Fix large file descriptor sets on 64-bit systems
+
+ -- Project Clearwater Maintainers <maintainers@projectclearwater.org>  Tue, 10 Jan 2017 10:17:19 +0000
+
+
 net-snmp (5.7.2~dfsg-clearwater5) trusty; urgency=medium
 
   * Fix bug with large file descriptor sets

--- a/snmplib/large_fd_set.c
+++ b/snmplib/large_fd_set.c
@@ -87,9 +87,9 @@ netsnmp_large_fd_is_set(SOCKET fd, netsnmp_large_fd_set * fdset)
  * Recent versions of glibc trigger abort() if FD_SET(), FD_CLR() or
  * FD_ISSET() is invoked with n >= FD_SETSIZE. Hence these replacement macros.
  */
-#define LFD_SET(n, p)    ((p)->fds_bits[(n)/NFDBITS] |=  (1 << ((n) % NFDBITS)))
-#define LFD_CLR(n, p)    ((p)->fds_bits[(n)/NFDBITS] &= ~(1 << ((n) % NFDBITS)))
-#define LFD_ISSET(n, p)  ((p)->fds_bits[(n)/NFDBITS] &   (1 << ((n) % NFDBITS)))
+#define LFD_SET(n, p)    ((p)->fds_bits[(n)/NFDBITS] |=  ((fd_mask)1 << ((n) % NFDBITS)))
+#define LFD_CLR(n, p)    ((p)->fds_bits[(n)/NFDBITS] &= ~((fd_mask)1 << ((n) % NFDBITS)))
+#define LFD_ISSET(n, p)  ((p)->fds_bits[(n)/NFDBITS] &   ((fd_mask)1 << ((n) % NFDBITS)))
 
 void
 netsnmp_large_fd_setfd(int fd, netsnmp_large_fd_set * fdset)

--- a/snmplib/large_fd_set.c
+++ b/snmplib/large_fd_set.c
@@ -85,11 +85,40 @@ netsnmp_large_fd_is_set(SOCKET fd, netsnmp_large_fd_set * fdset)
 
 /*
  * Recent versions of glibc trigger abort() if FD_SET(), FD_CLR() or
- * FD_ISSET() is invoked with n >= FD_SETSIZE. Hence these replacement macros.
+ * FD_ISSET() is invoked with n >= FD_SETSIZE. Hence these replacement
+ * functions. However, since NFDBITS != 8 * sizeof(fd_set.fds_bits[0]) for at
+ * least HP-UX on ia64 and since that combination uses big endian, use the
+ * macros from <sys/select.h> on such systems.
  */
-#define LFD_SET(n, p)    ((p)->fds_bits[(n)/NFDBITS] |=  ((fd_mask)1 << ((n) % NFDBITS)))
-#define LFD_CLR(n, p)    ((p)->fds_bits[(n)/NFDBITS] &= ~((fd_mask)1 << ((n) % NFDBITS)))
-#define LFD_ISSET(n, p)  ((p)->fds_bits[(n)/NFDBITS] &   ((fd_mask)1 << ((n) % NFDBITS)))
+NETSNMP_STATIC_INLINE void LFD_SET(unsigned n, fd_set *p)
+{
+    enum { nfdbits = 8 * sizeof(p->fds_bits[0]) };
+
+    if (nfdbits == NFDBITS)
+        p->fds_bits[n / nfdbits] |= (1ULL << (n % nfdbits));
+    else
+        FD_SET(n, p);
+}
+
+NETSNMP_STATIC_INLINE void LFD_CLR(unsigned n, fd_set *p)
+{
+    enum { nfdbits = 8 * sizeof(p->fds_bits[0]) };
+
+    if (nfdbits == NFDBITS)
+        p->fds_bits[n / nfdbits] &= ~(1ULL << (n % nfdbits));
+    else
+        FD_CLR(n, p);
+}
+
+NETSNMP_STATIC_INLINE unsigned LFD_ISSET(unsigned n, const fd_set *p)
+{
+    enum { nfdbits = 8 * sizeof(p->fds_bits[0]) };
+
+    if (nfdbits == NFDBITS)
+        return (p->fds_bits[n / nfdbits] & (1ULL << (n % nfdbits))) != 0;
+    else
+        return FD_ISSET(n, p) != 0;
+}
 
 void
 netsnmp_large_fd_setfd(int fd, netsnmp_large_fd_set * fdset)


### PR DESCRIPTION
Ellie,

Please can you review this fix to #10?  (Passing to you because you reviewed #8, which introduced this.)

As I wrote in #10:

>It's pretty subtle - basically, FD_SET, FD_CLR, FD_ISSET alias any file descriptors to ignore the 6th bit, i.e. it treats 3 the same as 35. Hence, on this particular system (where we have the right number of connections), file descriptor 35 (which ends up being Sprout) aliases to 3 (which seems to almost always be readable).
>
> The fix is to make sure gcc is using 64-bit long integers everywhere (if it's using 64-bit integers at all).

I've reviewed the assembly code and tested in a test harness, but not yet tested live - will do that tomorrow.

Matt