### PR TITLE
[Reviewer: Seb] Don't kill all snmp-owned processes

### DIFF
--- a/debian/snmp.preinst
+++ b/debian/snmp.preinst
@@ -12,8 +12,6 @@ install|upgrade)
     rm -rf /usr/doc/snmp
   fi
 
-  killall -u snmp 2>/dev/null || true
-
   ;;
 abort-upgrade)
   ;;


### PR DESCRIPTION
Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=781257 - as discussed in that thread, this line is now obsolete.

This caused mild chaos on one of my build systems - I was using Jenkins to install Clearwater inside a chroot, and the UIDs of `jenkins` (on the main system) and `snmp` (in the chroot) happened to match, so every time I installed snmp my Jenkins server got killed...